### PR TITLE
solution proposal discussion

### DIFF
--- a/Docker/boot-apps-docker-compose.yml
+++ b/Docker/boot-apps-docker-compose.yml
@@ -1,26 +1,7 @@
 version: "3"
 services:
-  zookeeper:
-    image: 'bitnami/zookeeper:${ZOOKEEPER_TAG:-latest}'
-    ports:
-      - '2181:2181'
-    environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
-  kafka:
-    image: 'bitnami/kafka:${KAFKA_TAG:-latest}'
-    ports:
-      - '9092:9092'
-    environment:
-      - KAFKA_BROKER_ID=1
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - LOG_RETENTION_HOURS=26280
-    depends_on:
-      - zookeeper
   order-command:
-    image: 'noahhsu/espoc/order/command-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    image: 'noahhsu/espoc/order/command-side:${APP_TAG:-latest}'
     ports:
       - '8081:8081'
     depends_on:
@@ -29,8 +10,10 @@ services:
       - all
       - order
       - command
+    networks:
+      - espoc
   order-handler:
-    image: 'noahhsu/espoc/order/event-handler:${APP_TAG:-0.0.1-SNAPSHOT}'
+    image: 'noahhsu/espoc/order/event-handler:${APP_TAG:-latest}'
     ports:
       - '8082:8082'
     depends_on:
@@ -39,8 +22,10 @@ services:
       - all
       - order
       - handler
+    networks:
+      - espoc
   order-query:
-    image: 'noahhsu/espoc/order/query-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    image: 'noahhsu/espoc/order/query-side:${APP_TAG:-latest}'
     ports:
       - '8083:8083'
     depends_on:
@@ -49,8 +34,10 @@ services:
       - all
       - order
       - query
+    networks:
+      - espoc
   payment-command:
-    image: 'noahhsu/espoc/payment/command-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    image: 'noahhsu/espoc/payment/command-side:${APP_TAG:-latest}'
     ports:
       - '8084:8084'
     depends_on:
@@ -59,8 +46,10 @@ services:
       - all
       - payment
       - command
+    networks:
+      - espoc
   payment-handler:
-    image: 'noahhsu/espoc/payment/event-handler:${APP_TAG:-0.0.1-SNAPSHOT}'
+    image: 'noahhsu/espoc/payment/event-handler:${APP_TAG:-latest}'
     ports:
       - '8085:8085'
     depends_on:
@@ -69,8 +58,10 @@ services:
       - all
       - payment
       - handler
+    networks:
+      - espoc
   payment-query:
-    image: 'noahhsu/espoc/payment/query-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    image: 'noahhsu/espoc/payment/query-side:${APP_TAG:-latest}'
     ports:
       - '8086:8086'
     depends_on:
@@ -79,8 +70,10 @@ services:
       - all
       - payment
       - query
+    networks:
+      - espoc
   shipment-command:
-    image: 'noahhsu/espoc/shipment/command-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    image: 'noahhsu/espoc/shipment/command-side:${APP_TAG:-latest}'
     ports:
       - '8087:8087'
     depends_on:
@@ -89,8 +82,10 @@ services:
       - all
       - shipment
       - command
+    networks:
+      - espoc
   shipment-handler:
-    image: 'noahhsu/espoc/shipment/event-handler:${APP_TAG:-0.0.1-SNAPSHOT}'
+    image: 'noahhsu/espoc/shipment/event-handler:${APP_TAG:-latest}'
     ports:
       - '8088:8088'
     depends_on:
@@ -99,8 +94,10 @@ services:
       - all
       - shipment
       - handler
+    networks:
+      - espoc
   shipment-query:
-    image: 'noahhsu/espoc/shipment/query-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    image: 'noahhsu/espoc/shipment/query-side:${APP_TAG:-latest}'
     ports:
       - '8089:8089'
     depends_on:
@@ -109,3 +106,8 @@ services:
       - all
       - shipment
       - query
+    networks:
+      - espoc
+
+networks:
+  espoc:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "3"
 services:
   zookeeper:
-    image: 'bitnami/zookeeper:latest'
+    image: 'bitnami/zookeeper:${ZOOKEEPER_TAG:-latest}'
     ports:
       - '2181:2181'
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: 'bitnami/kafka:latest'
+    image: 'bitnami/kafka:${KAFKA_TAG:-latest}'
     ports:
       - '9092:9092'
     environment:
@@ -16,6 +16,96 @@ services:
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
       - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
       - ALLOW_PLAINTEXT_LISTENER=yes
-      - LOG_RETENTION_HOURS= 26280
+      - LOG_RETENTION_HOURS=26280
     depends_on:
       - zookeeper
+  order-command:
+    image: 'noahhsu/espoc/order/command-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    ports:
+      - '8081:8081'
+    depends_on:
+      - kafka
+    profiles:
+      - all
+      - order
+      - command
+  order-handler:
+    image: 'noahhsu/espoc/order/event-handler:${APP_TAG:-0.0.1-SNAPSHOT}'
+    ports:
+      - '8082:8082'
+    depends_on:
+      - kafka
+    profiles:
+      - all
+      - order
+      - handler
+  order-query:
+    image: 'noahhsu/espoc/order/query-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    ports:
+      - '8083:8083'
+    depends_on:
+      - kafka
+    profiles:
+      - all
+      - order
+      - query
+  payment-command:
+    image: 'noahhsu/espoc/payment/command-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    ports:
+      - '8084:8084'
+    depends_on:
+      - kafka
+    profiles:
+      - all
+      - payment
+      - command
+  payment-handler:
+    image: 'noahhsu/espoc/payment/event-handler:${APP_TAG:-0.0.1-SNAPSHOT}'
+    ports:
+      - '8085:8085'
+    depends_on:
+      - kafka
+    profiles:
+      - all
+      - payment
+      - handler
+  payment-query:
+    image: 'noahhsu/espoc/payment/query-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    ports:
+      - '8086:8086'
+    depends_on:
+      - kafka
+    profiles:
+      - all
+      - payment
+      - query
+  shipment-command:
+    image: 'noahhsu/espoc/shipment/command-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    ports:
+      - '8087:8087'
+    depends_on:
+      - kafka
+    profiles:
+      - all
+      - shipment
+      - command
+  shipment-handler:
+    image: 'noahhsu/espoc/shipment/event-handler:${APP_TAG:-0.0.1-SNAPSHOT}'
+    ports:
+      - '8088:8088'
+    depends_on:
+      - kafka
+    profiles:
+      - all
+      - shipment
+      - handler
+  shipment-query:
+    image: 'noahhsu/espoc/shipment/query-side:${APP_TAG:-0.0.1-SNAPSHOT}'
+    ports:
+      - '8089:8089'
+    depends_on:
+      - kafka
+    profiles:
+      - all
+      - shipment
+      - query

--- a/Docker/kafka-docker-compose.yml
+++ b/Docker/kafka-docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3"
+services:
+  zookeeper:
+    image: 'bitnami/zookeeper:${ZOOKEEPER_TAG:-latest}'
+    ports:
+      - '2181:2181'
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    networks:
+      - espoc
+  kafka:
+    image: 'bitnami/kafka:${KAFKA_TAG:-latest}'
+    ports:
+      - '9092:9092'
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - LOG_RETENTION_HOURS=26280
+    depends_on:
+      - zookeeper
+    networks:
+      - espoc
+
+networks:
+  espoc:

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
     id 'org.springframework.boot' version "${springBootVersion}" apply false
     id 'io.spring.dependency-management' version "${springDependencyVersion}" apply false
@@ -15,6 +17,9 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'java-library'
+    apply plugin: 'com.google.cloud.tools.jib'
+
+    jib.to.tags = ["latest"]
 
     repositories {
         mavenCentral()
@@ -22,7 +27,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+            mavenBom SpringBootPlugin.BOM_COORDINATES
         }
     }
 
@@ -36,6 +41,7 @@ subprojects {
         compileOnly 'org.projectlombok:lombok:1.18.20'
         annotationProcessor 'org.projectlombok:lombok:1.18.20'
     }
+
     test {
         useJUnitPlatform()
     }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,3 +13,5 @@ bootJar {
 jar {
     enabled = true
 }
+
+tasks.findAll { it.name.startsWith("jib") }.forEach { it.enabled = false }

--- a/order/build.gradle
+++ b/order/build.gradle
@@ -1,3 +1,5 @@
 bootJar {
     enabled = false
 }
+
+tasks.findAll { it.name.startsWith("jib") }.forEach { it.enabled = false }

--- a/order/command-side/build.gradle
+++ b/order/command-side/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib.to.image = "noahhsu/espoc/order/${project.name}:${version}"
+jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/order/command-side/build.gradle
+++ b/order/command-side/build.gradle
@@ -1,8 +1,4 @@
-plugins {
-    id 'com.google.cloud.tools.jib'
-}
 jib.to.image = "noahhsu/espoc/order/${project.name}:${version}"
-jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/order/command-side/src/main/resources/application.yaml
+++ b/order/command-side/src/main/resources/application.yaml
@@ -5,10 +5,10 @@ spring:
   application:
     name: command-side-order
   kafka:
-    bootstrapServers: localhost:9092
+    bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
     producer:
       retries: 3
-      bootstrapServers: localhost:9092
+      bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-Serializer: org.springframework.kafka.support.serializer.JsonSerializer
       transaction-id-prefix: poc-es

--- a/order/event-handler/build.gradle
+++ b/order/event-handler/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib.to.image = "noahhsu/espoc/order/${project.name}:${version}"
+jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/order/event-handler/build.gradle
+++ b/order/event-handler/build.gradle
@@ -1,8 +1,4 @@
-plugins {
-    id 'com.google.cloud.tools.jib'
-}
 jib.to.image = "noahhsu/espoc/order/${project.name}:${version}"
-jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/order/event-handler/src/main/resources/application.yaml
+++ b/order/event-handler/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
   application:
     name: query-side-order
   kafka:
-    bootstrapServers: localhost:9092
+    bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer

--- a/order/query-side/build.gradle
+++ b/order/query-side/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib.to.image = "noahhsu/espoc/order/${project.name}:${version}"
+jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/order/query-side/build.gradle
+++ b/order/query-side/build.gradle
@@ -1,8 +1,4 @@
-plugins {
-    id 'com.google.cloud.tools.jib'
-}
 jib.to.image = "noahhsu/espoc/order/${project.name}:${version}"
-jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/order/query-side/src/main/resources/application.yaml
+++ b/order/query-side/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
   application:
     name: query-side
   kafka:
-    bootstrapServers: localhost:9092
+    bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -1,3 +1,5 @@
 bootJar {
     enabled = false
 }
+
+tasks.findAll { it.name.startsWith("jib") }.forEach { it.enabled = false }

--- a/payment/command-side/build.gradle
+++ b/payment/command-side/build.gradle
@@ -1,8 +1,4 @@
-plugins {
-    id 'com.google.cloud.tools.jib'
-}
 jib.to.image = "noahhsu/espoc/payment/${project.name}:${version}"
-jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/payment/command-side/build.gradle
+++ b/payment/command-side/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib.to.image = "noahhsu/espoc/payment/${project.name}:${version}"
+jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/payment/command-side/src/main/resources/application.yaml
+++ b/payment/command-side/src/main/resources/application.yaml
@@ -5,10 +5,10 @@ spring:
   application:
     name: command-side-payment
   kafka:
-    bootstrapServers: localhost:9092
+    bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
     producer:
       retries: 3
-      bootstrapServers: localhost:9092
+      bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-Serializer: org.springframework.kafka.support.serializer.JsonSerializer
       transaction-id-prefix: poc-es

--- a/payment/event-handler/build.gradle
+++ b/payment/event-handler/build.gradle
@@ -1,8 +1,4 @@
-plugins {
-    id 'com.google.cloud.tools.jib'
-}
 jib.to.image = "noahhsu/espoc/payment/${project.name}:${version}"
-jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/payment/event-handler/build.gradle
+++ b/payment/event-handler/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib.to.image = "noahhsu/espoc/payment/${project.name}:${version}"
+jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/payment/event-handler/src/main/resources/application.yaml
+++ b/payment/event-handler/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
   application:
     name: query-side-payment
   kafka:
-    bootstrapServers: localhost:9092
+    bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer

--- a/payment/query-side/build.gradle
+++ b/payment/query-side/build.gradle
@@ -1,8 +1,4 @@
-plugins {
-    id 'com.google.cloud.tools.jib'
-}
 jib.to.image = "noahhsu/espoc/payment/${project.name}:${version}"
-jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/payment/query-side/build.gradle
+++ b/payment/query-side/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib.to.image = "noahhsu/espoc/payment/${project.name}:${version}"
+jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/payment/query-side/src/main/resources/application.yaml
+++ b/payment/query-side/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
   application:
     name: query-side-payment
   kafka:
-    bootstrapServers: localhost:9092
+    bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer

--- a/shipment/build.gradle
+++ b/shipment/build.gradle
@@ -1,3 +1,5 @@
 bootJar {
     enabled = false
 }
+
+tasks.findAll { it.name.startsWith("jib") }.forEach { it.enabled = false }

--- a/shipment/command-side/build.gradle
+++ b/shipment/command-side/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib.to.image = "noahhsu/espoc/shipment/${project.name}:${version}"
+jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/shipment/command-side/build.gradle
+++ b/shipment/command-side/build.gradle
@@ -1,8 +1,4 @@
-plugins {
-    id 'com.google.cloud.tools.jib'
-}
 jib.to.image = "noahhsu/espoc/shipment/${project.name}:${version}"
-jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/shipment/command-side/src/main/resources/application.yaml
+++ b/shipment/command-side/src/main/resources/application.yaml
@@ -5,10 +5,10 @@ spring:
   application:
     name: command-side-shipment
   kafka:
-    bootstrapServers: localhost:9092
+    bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
     producer:
       retries: 3
-      bootstrapServers: localhost:9092
+      bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-Serializer: org.springframework.kafka.support.serializer.JsonSerializer
       transaction-id-prefix: poc-es

--- a/shipment/event-handler/build.gradle
+++ b/shipment/event-handler/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib.to.image = "noahhsu/espoc/shipment/${project.name}:${version}"
+jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/shipment/event-handler/build.gradle
+++ b/shipment/event-handler/build.gradle
@@ -1,8 +1,4 @@
-plugins {
-    id 'com.google.cloud.tools.jib'
-}
 jib.to.image = "noahhsu/espoc/shipment/${project.name}:${version}"
-jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/shipment/event-handler/src/main/resources/application.yaml
+++ b/shipment/event-handler/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
   application:
     name: query-side-shipment
   kafka:
-    bootstrapServers: localhost:9092
+    bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer

--- a/shipment/query-side/build.gradle
+++ b/shipment/query-side/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib.to.image = "noahhsu/espoc/shipment/${project.name}:${version}"
+jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/shipment/query-side/build.gradle
+++ b/shipment/query-side/build.gradle
@@ -1,8 +1,4 @@
-plugins {
-    id 'com.google.cloud.tools.jib'
-}
 jib.to.image = "noahhsu/espoc/shipment/${project.name}:${version}"
-jib.to.tags = ["latest"]
 
 dependencies {
     implementation project(":common")

--- a/shipment/query-side/src/main/resources/application.yaml
+++ b/shipment/query-side/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
   application:
     name: query-side-shipment
   kafka:
-    bootstrapServers: localhost:9092
+    bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer


### PR DESCRIPTION
## Description
Add services with profile setting and use tag variables in docker compose.

### Solution

Let's use capital letters to represent which services are started

K=kafka
Z=zookeeper
O=order
P=payment
S=shipment
C=command
H=handler
Q=query

e.g.
OC=order command

`docker compose up` -> K and Z (2)
No matter which profiles are specifed, K and Z will always start. I'm omit them in the outcome list from now on (but included in the count).

`docker compose --profile all up` -> all services (11)

`docker compose --profile order --profile payment up`  or
`COMPOSE_PROFILES=order,payment docker compose up`  -> all O's and all P's (8)

`COMPOSE_PROFILES=order,command docker compose up` -> all O's, PC and SC (7)
 
`COMPOSE_PROFILES=all docker compose up --scale order-command=0 --scale payment-command=0` -> all except OC and PC (9)
I think this is the closest to "excluding" feature in docker compose. There is a downside though.

Generally, if you just use `docker compose stop` then the containers will stay in "exited" state but not removed. When using `docker compose up --scale xxxservice=0`, xxxservice will be removed from the compose project. Of course if our use case is using `docker compose down` to tear up everything, then it's not a problem.

I think we should first discuss about the behavior of this solution then proceed to next step (write shortcut/alias with makefile?).

By the way, when I run `gradlew jibDockerBuild`, the image tag is the maven artirfact version(0.0.1-SNAPSHOT). Is that intended or we will change it to/add "latest"?

## Changes

edit docker compose yml
