### PR TITLE
[#52] Kafka consumer (Query-Side) error handling (order only)

### DIFF
--- a/.github/workflows/E2E_test.yaml
+++ b/.github/workflows/E2E_test.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           url: http://localhost:8083/actuator/health
           max-attempts: 6
-          retry-delay: 10s
+          retry-delay: 15s
           retry-all: true
 
       - name: Check the order-command

--- a/Docker/kafka-docker-compose.yml
+++ b/Docker/kafka-docker-compose.yml
@@ -7,4 +7,4 @@ services:
       - '9092:9092'
     environment:
       - ALLOW_PLAINTEXT_LISTENER=yes
-      - LOG_RETENTION_HOURS=26280
+      - LOG_RETENTION_HOURS=1

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 #### Prepare dependency services by docker-compose for run application outside docker
 ```shell
 # should rim build first
-./gradlew -Dskip.tests build
+./gradlew build -x test
 # run order command query and others
 docker compose -f Docker/observe-docker-compose.yaml -f Docker/boot-run-apps-docker-compose.yml -f Docker/kafka-docker-compose.yml --env-file Docker/config/.env.docker -p event-sourcing up -d --scale prometheus=0
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   - consume events from Kafka to send command request to Command-side
 
 ## How to run application
-#### Prepare dependency services by docker-compose for run application outside docker
+### With local code
 ```shell
 # should rim build first
 ./gradlew build -x test
@@ -28,14 +28,8 @@
 docker compose -f Docker/observe-docker-compose.yaml -f Docker/boot-run-apps-docker-compose.yml -f Docker/kafka-docker-compose.yml --env-file Docker/config/.env.docker -p event-sourcing up -d --scale prometheus=0
 ```
 
-```shell
-# observability components for application 
-docker compose -f Docker/observe-docker-compose.yaml -p event-sourcing-observe up
-# kafka for application
-docker compose -f Docker/kafka-docker-compose.yml -p event-sourcing-kafka up
-```
 #### Run applications 
-- run by docker-compose
+### With docker image on the Docker Hub 
 ```shell
 # all service with all observability components and kafka
 docker compose -f Docker/observe-docker-compose.yaml -f Docker/boot-apps-docker-compose.yml -f Docker/kafka-docker-compose.yml --env-file Docker/config/.env.docker --profile order  -p event-sourcing up
@@ -48,13 +42,6 @@ docker compose -f Docker/boot-apps-docker-compose.yml -f Docker/kafka-docker-com
 # only shipment-command-side
 docker compose -f Docker/boot-apps-docker-compose.yml -f Docker/kafka-docker-compose.yml --env-file Docker/config/.env.docker --profile shipment -p event-sourcing up --scale shipment-handler=0 --scale shipment-query=0
 ``` 
-
-- run by terminal:
-
-```
-./../../gradlew bootRun
-```
-
 
 - run by IDE 
   

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@
 ## How to run application
 #### Prepare dependency services by docker-compose for run application outside docker
 ```shell
+# should rim build first
+./gradlew -Dskip.tests build
+# run order command query and others
+docker compose -f Docker/observe-docker-compose.yaml -f Docker/boot-run-apps-docker-compose.yml -f Docker/kafka-docker-compose.yml --env-file Docker/config/.env.docker -p event-sourcing up -d --scale prometheus=0
+```
+
+```shell
 # observability components for application 
 docker compose -f Docker/observe-docker-compose.yaml -p event-sourcing-observe up
 # kafka for application
@@ -31,7 +38,7 @@ docker compose -f Docker/kafka-docker-compose.yml -p event-sourcing-kafka up
 - run by docker-compose
 ```shell
 # all service with all observability components and kafka
-docker compose -f Docker/observe-docker-compose.yaml -f Docker/boot-apps-docker-compose.yml -f Docker/kafka-docker-compose.yml --env-file Docker/config/.env.docker -p event-sourcing up
+docker compose -f Docker/observe-docker-compose.yaml -f Docker/boot-apps-docker-compose.yml -f Docker/kafka-docker-compose.yml --env-file Docker/config/.env.docker --profile order  -p event-sourcing up
 # all order service without
 docker compose -f Docker/boot-apps-docker-compose.yml -f Docker/kafka-docker-compose.yml --env-file Docker/config/.env.docker --profile order -p event-sourcing up
 # only order-command-side

--- a/event/src/main/java/org/example/event/sourcing/order/poc/event/config/TopicConfig.java
+++ b/event/src/main/java/org/example/event/sourcing/order/poc/event/config/TopicConfig.java
@@ -18,6 +18,7 @@ public class TopicConfig {
     public NewTopic orderEvent() {
         return TopicBuilder.name(ORDER_TOPIC)
                 .partitions(ORDER_TOPIC_PARTITION)
+                .config(org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG, String.valueOf(Long.MAX_VALUE))
                 .compact()
                 .build();
     }
@@ -25,6 +26,7 @@ public class TopicConfig {
     public NewTopic paymentEvent() {
         return TopicBuilder.name(PAYMENT_TOPIC)
                 .partitions(PAYMENT_TOPIC_PARTITION)
+                .config(org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG, String.valueOf(Long.MAX_VALUE))
                 .compact()
                 .build();
     }
@@ -33,15 +35,7 @@ public class TopicConfig {
     public NewTopic shipmentEvent() {
         return TopicBuilder.name(SHIPMENT_TOPIC)
                 .partitions(SHIPMENT_TOPIC_PARTITION)
-                .compact()
-                .build();
-    }
-
-    @Bean
-    public NewTopic orderRequeueEvent() {
-        return TopicBuilder.name(ORDER_REQUEUE_TOPIC)
-                .partitions(1)
-                .config(org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG, "10000")
+                .config(org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG, String.valueOf(Long.MAX_VALUE))
                 .compact()
                 .build();
     }

--- a/event/src/main/java/org/example/event/sourcing/order/poc/event/config/TopicConfig.java
+++ b/event/src/main/java/org/example/event/sourcing/order/poc/event/config/TopicConfig.java
@@ -5,8 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
 
-import static org.example.event.sourcing.order.poc.event.model.OrderEvent.ORDER_TOPIC;
-import static org.example.event.sourcing.order.poc.event.model.OrderEvent.ORDER_TOPIC_PARTITION;
+import static org.example.event.sourcing.order.poc.event.model.OrderEvent.*;
 import static org.example.event.sourcing.order.poc.event.model.PaymentEvent.PAYMENT_TOPIC;
 import static org.example.event.sourcing.order.poc.event.model.PaymentEvent.PAYMENT_TOPIC_PARTITION;
 import static org.example.event.sourcing.order.poc.event.model.ShipmentEvent.SHIPMENT_TOPIC;
@@ -34,6 +33,15 @@ public class TopicConfig {
     public NewTopic shipmentEvent() {
         return TopicBuilder.name(SHIPMENT_TOPIC)
                 .partitions(SHIPMENT_TOPIC_PARTITION)
+                .compact()
+                .build();
+    }
+
+    @Bean
+    public NewTopic orderRequeueEvent() {
+        return TopicBuilder.name(ORDER_REQUEUE_TOPIC)
+                .partitions(1)
+                .config(org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG, "10000")
                 .compact()
                 .build();
     }

--- a/event/src/main/java/org/example/event/sourcing/order/poc/event/model/OrderEvent.java
+++ b/event/src/main/java/org/example/event/sourcing/order/poc/event/model/OrderEvent.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 public record OrderEvent(String id, OrderEventName eventName, Instant createdDate) {
 
     public static final String ORDER_TOPIC = "ORDER";
+    public static final String ORDER_REQUEUE_TOPIC = "ORDER.RE";
     public static final int ORDER_TOPIC_PARTITION = 3;
 
     public static final String ORDER_EVENT_HANDLER_GROUP_ID = "ORDER-HANDLER";

--- a/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/config/KafkaConfig.java
+++ b/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/config/KafkaConfig.java
@@ -2,66 +2,24 @@ package org.example.event.sourcing.order.poc.query.order.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.example.event.sourcing.order.poc.event.model.OrderEvent;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.kafka.core.DefaultKafkaProducerFactory;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.listener.ConsumerRecordRecoverer;
-import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
-import org.springframework.kafka.listener.DefaultErrorHandler;
-import org.springframework.kafka.listener.KafkaListenerErrorHandler;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurationSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.util.backoff.FixedBackOff;
 
-import java.util.List;
-import java.util.function.BiConsumer;
-
-import static org.example.event.sourcing.order.poc.event.model.OrderEvent.ORDER_REQUEUE_TOPIC;
-import static org.example.event.sourcing.order.poc.event.model.OrderEvent.ORDER_TOPIC;
+import java.io.IOException;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableScheduling
 @Slf4j
-public class KafkaConfig {
+public class KafkaConfig extends RetryTopicConfigurationSupport {
 
-    @Bean
-    DefaultErrorHandler orderRequeueEventErrorHandler(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
-        DeadLetterPublishingRecoverer deadLetterPublisher = getDeadLetterPublishingRecoverer(kafkaTemplate);
-        return new DefaultErrorHandler(deadLetterPublisher, new FixedBackOff(60000, 2));
-    }
-
-    private static DeadLetterPublishingRecoverer getDeadLetterPublishingRecoverer(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
-        DeadLetterPublishingRecoverer deadLetterPublisher = new DeadLetterPublishingRecoverer(kafkaTemplate);
-        deadLetterPublisher.excludeHeader(DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.EX_STACKTRACE);
-        return deadLetterPublisher;
-    }
-
-    @Bean
-    @Primary
-    DefaultErrorHandler orderMainEventErrorHandler(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
-        ConsumerRecordRecoverer requeueRecoverer = recoverer(kafkaTemplate);
-        return new DefaultErrorHandler(requeueRecoverer, new FixedBackOff(5000, 2));
-    }
-
-
-    private ConsumerRecordRecoverer recoverer(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
-        DeadLetterPublishingRecoverer deadLetterPublisher = getDeadLetterPublishingRecoverer(kafkaTemplate);
-        List<Class<? extends Throwable>> deadExceptions = DeadLetterPublishingRecoverer.defaultFatalExceptionsList();
-        ConsumerRecordRecoverer result = (ConsumerRecord<?, ?> consumerRecord, Exception e) -> {
-            log.warn("in orderMainEventErrorHandler e = {}", e.getCause().getClass().getSimpleName(), e.getCause());
-            if (consumerRecord.topic().equals(ORDER_TOPIC) &&
-                    !deadExceptions.contains(e.getCause().getClass())) {
-                String toTopic = ORDER_REQUEUE_TOPIC;
-                String key = (String) consumerRecord.key();
-                OrderEvent message = (OrderEvent) consumerRecord.value();
-                kafkaTemplate.send(toTopic, key, message);
-            } else {
-                deadLetterPublisher.accept(consumerRecord, e);
-            }
-        };
-        return result;
+    @Override
+    protected void configureBlockingRetries(BlockingRetriesConfigurer blockingRetries) {
+        blockingRetries
+                .retryOn(IOException.class)
+                .backOff(new FixedBackOff(5000, 3));
     }
 
 }

--- a/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/config/KafkaConfig.java
+++ b/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/config/KafkaConfig.java
@@ -1,0 +1,67 @@
+package org.example.event.sourcing.order.poc.query.order.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.example.event.sourcing.order.poc.event.model.OrderEvent;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ConsumerRecordRecoverer;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static org.example.event.sourcing.order.poc.event.model.OrderEvent.ORDER_REQUEUE_TOPIC;
+import static org.example.event.sourcing.order.poc.event.model.OrderEvent.ORDER_TOPIC;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaConfig {
+
+    @Bean
+    DefaultErrorHandler orderRequeueEventErrorHandler(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+        DeadLetterPublishingRecoverer deadLetterPublisher = getDeadLetterPublishingRecoverer(kafkaTemplate);
+        return new DefaultErrorHandler(deadLetterPublisher, new FixedBackOff(60000, 2));
+    }
+
+    private static DeadLetterPublishingRecoverer getDeadLetterPublishingRecoverer(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+        DeadLetterPublishingRecoverer deadLetterPublisher = new DeadLetterPublishingRecoverer(kafkaTemplate);
+        deadLetterPublisher.excludeHeader(DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.EX_STACKTRACE);
+        return deadLetterPublisher;
+    }
+
+    @Bean
+    @Primary
+    DefaultErrorHandler orderMainEventErrorHandler(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+        ConsumerRecordRecoverer requeueRecoverer = recoverer(kafkaTemplate);
+        return new DefaultErrorHandler(requeueRecoverer, new FixedBackOff(5000, 2));
+    }
+
+
+    private ConsumerRecordRecoverer recoverer(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+        DeadLetterPublishingRecoverer deadLetterPublisher = getDeadLetterPublishingRecoverer(kafkaTemplate);
+        List<Class<? extends Throwable>> deadExceptions = DeadLetterPublishingRecoverer.defaultFatalExceptionsList();
+        ConsumerRecordRecoverer result = (ConsumerRecord<?, ?> consumerRecord, Exception e) -> {
+            log.warn("in orderMainEventErrorHandler e = {}", e.getCause().getClass().getSimpleName(), e.getCause());
+            if (consumerRecord.topic().equals(ORDER_TOPIC) &&
+                    !deadExceptions.contains(e.getCause().getClass())) {
+                String toTopic = ORDER_REQUEUE_TOPIC;
+                String key = (String) consumerRecord.key();
+                OrderEvent message = (OrderEvent) consumerRecord.value();
+                kafkaTemplate.send(toTopic, key, message);
+            } else {
+                deadLetterPublisher.accept(consumerRecord, e);
+            }
+        };
+        return result;
+    }
+
+}

--- a/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/consumer/OrderEventConsumer.java
+++ b/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/consumer/OrderEventConsumer.java
@@ -6,10 +6,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.event.sourcing.order.poc.event.model.OrderEvent;
 import org.example.event.sourcing.order.poc.query.order.domain.handler.OrderEventRecordHandler;
 import org.example.event.sourcing.order.poc.query.order.domain.handler.OrderRecordHandler;
+import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.net.SocketException;
 
 import static org.example.event.sourcing.order.poc.event.model.OrderEvent.*;
 
@@ -23,13 +31,24 @@ public class OrderEventConsumer {
 
     private final OrderEventRecordHandler orderEventRecordHandler;
 
+    private final KafkaTemplate<String, OrderEvent> kafkaTemplate;
+
+    @RetryableTopic(kafkaTemplate = "kafkaTemplate",
+            attempts = "4",
+            backoff = @Backoff(delay = 3000, multiplier = 1.5, maxDelay = 15000)
+    )
     @KafkaListener(topics = ORDER_TOPIC, groupId = ORDER_STATUS_GROUP_ID_PREFIX + "#{ T(java.util.UUID).randomUUID().toString() }")
     @Transactional
-    public void orderEventListener(OrderEvent orderEvent, Acknowledgment ack) {
-        log.info("main topic handler receive data = {}", orderEvent);
+    public void orderEventListener(@Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
+                                   OrderEvent orderEvent, Acknowledgment ack) throws SocketException {
+        log.info("Topic({}) handler receive data = {}", receivedTopic, orderEvent);
         try {
             orderEventRecordHandler.onEvent(orderEvent);
-            orderRecordHandler.onEvent(orderEvent);
+            if (receivedTopic.contains("retry")) {
+                orderRecordHandler.onRequeueEvent(orderEvent);
+            } else {
+                orderRecordHandler.onEvent(orderEvent);
+            }
             ack.acknowledge();
         } catch (Exception e) {
             log.warn("Fail to handle event {}.", orderEvent);
@@ -37,18 +56,9 @@ public class OrderEventConsumer {
         }
     }
 
-    @KafkaListener(topics = ORDER_REQUEUE_TOPIC, groupId = ORDER_STATUS_GROUP_ID_PREFIX + "#{ T(java.util.UUID).randomUUID().toString() }")
-    @Transactional
-    public void orderReQueueEventListener(OrderEvent orderEvent, Acknowledgment ack) {
-        log.info("requeue topic handler receive data = {}", orderEvent);
-        try {
-            orderEventRecordHandler.onEvent(orderEvent);
-            orderRecordHandler.onRequeueEvent(orderEvent);
-            ack.acknowledge();
-        } catch (Exception e) {
-            log.warn("Fail to handle event {}.", orderEvent);
-            throw e;
-        }
+    @DltHandler
+    public void processMessage(OrderEvent message) {
+        log.error("DltHandler processMessage = {}", message);
     }
 
 }

--- a/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/entity/OrderEventRecord.java
+++ b/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/entity/OrderEventRecord.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.Instant;
 
 @Entity
-@Table(name = "ORDER_EVENT_RECORD")
+@Table(name = "ORDER_EVENT_RECORD", indexes = @Index(columnList = "orderId"))
 @EntityListeners(AuditingEntityListener.class)
 
 @Data

--- a/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/handler/OrderEventRecordHandler.java
+++ b/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/handler/OrderEventRecordHandler.java
@@ -5,5 +5,6 @@ import org.example.event.sourcing.order.poc.event.model.OrderEvent;
 import java.util.concurrent.CompletableFuture;
 
 public interface OrderEventRecordHandler {
-    CompletableFuture<Void> onEvent(OrderEvent event);
+    void onEvent(OrderEvent event);
+    
 }

--- a/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/handler/OrderRecordHandler.java
+++ b/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/handler/OrderRecordHandler.java
@@ -5,5 +5,8 @@ import org.example.event.sourcing.order.poc.event.model.OrderEvent;
 import java.util.concurrent.CompletableFuture;
 
 public interface OrderRecordHandler {
-    CompletableFuture<Void> onEvent(OrderEvent event);
+    void onEvent(OrderEvent event);
+
+    void onRequeueEvent(OrderEvent event);
+
 }

--- a/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/handler/OrderRecordHandler.java
+++ b/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/handler/OrderRecordHandler.java
@@ -2,10 +2,10 @@ package org.example.event.sourcing.order.poc.query.order.domain.handler;
 
 import org.example.event.sourcing.order.poc.event.model.OrderEvent;
 
-import java.util.concurrent.CompletableFuture;
+import java.net.SocketException;
 
 public interface OrderRecordHandler {
-    void onEvent(OrderEvent event);
+    void onEvent(OrderEvent event) throws SocketException;
 
     void onRequeueEvent(OrderEvent event);
 

--- a/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/handler/impl/OrderEventRecordHandlerImpl.java
+++ b/order/query-side/src/main/java/org/example/event/sourcing/order/poc/query/order/domain/handler/impl/OrderEventRecordHandlerImpl.java
@@ -21,19 +21,17 @@ public class OrderEventRecordHandlerImpl implements OrderEventRecordHandler {
     private final OrderEventRepository orderEventRepository;
 
     @Override
-    public CompletableFuture<Void> onEvent(OrderEvent event) {
-        return CompletableFuture.runAsync(() -> {
-            switch (event.eventName()) {
-                case CREATED:
-                    createOrder(event);
-                    break;
-                case COMPLETED:
-                    prepareOrder(event);
-                    break;
-                default:
-                    throw new RuntimeException("unsupported event name");
-            }
-        });
+    public void onEvent(OrderEvent event) {
+        switch (event.eventName()) {
+            case CREATED:
+                createOrder(event);
+                break;
+            case COMPLETED:
+                prepareOrder(event);
+                break;
+            default:
+                throw new RuntimeException("unsupported event name");
+        }
     }
 
 

--- a/order/query-side/src/main/resources/application.yaml
+++ b/order/query-side/src/main/resources/application.yaml
@@ -29,6 +29,11 @@ spring:
         format_sql: true
   kafka:
     bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
+    producer:
+      retries: 3
+      bootstrapServers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-Serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer


### PR DESCRIPTION
## Description
- Propose a way to do both Blocking and Non-blocking error handling in order-query-side
## Changes
- combine OrderEvent and OrderEventRecord Handler into one Handler with Transaction
- change Handler from async handle to synchronize
- apply a mocking logic for mock Exceptions when handling events
- change default topic retention hours to 1 (but set the topic for event-sourcing as Long.MaxValue() in config code)
## Screenshot(Optional)
- local run act on E2E test success
![image](https://github.com/NoahHsu/event-sourcing-order-poc/assets/58896446/f875881d-90ad-4052-a4fe-0276fcb6cd14)

